### PR TITLE
Feat/winner logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The main contract `SwarmCoordinator` manages a round-based system for coordinati
 1. **Owner**
    - Can set stage durations and count
    - Can assign bootnode manager role
-   - Can add and remove judges
+   - Can set judge
    - Initially deployed contract owner
 
 2. **Bootnode Manager**
@@ -47,10 +47,9 @@ The main contract `SwarmCoordinator` manages a round-based system for coordinati
    - Can clear all bootnodes
    - Initially set to contract owner
 
-3. **Judges**
-   - Can submit winners for completed rounds
-   - Assigns rewards to winners
-   - Multiple judges can be active simultaneously
+3. **Judge**
+   - Single address authorized to submit winners for completed rounds
+   - Can be a smart contract implementing custom consensus logic
    - Initially set to contract owner
 
 ## Interacting with the Contract
@@ -86,8 +85,7 @@ Manages stages and other managers.
 function setStageCount(uint256 stageCount_)
 function setStageDuration(uint256 stage_, uint256 stageDuration_)
 function setBootnodeManager(address newManager)
-function addJudge(address newJudge)
-function removeJudge(address judgeToRemove)
+function setJudge(address newJudge)
 ```
 
 #### Bootnode manager
@@ -100,15 +98,14 @@ function removeBootnode(uint256 index)
 function clearBootnodes()
 ```
 
-#### Judges
+#### Judge
 
-Submit winners. Can be defined as different smart contracts that manage consensus before posting a winner.
+Submits winners. Can be a smart contract implementing custom consensus logic.
 
 ```solidity
 function submitWinner(uint256 roundNumber, address[] calldata winners)
 function getRoundWinners(uint256 roundNumber) external view returns (address[] memory)
-function isJudge(address account) external view returns (bool)
-function getJudgeCount() external view returns (uint256)
+function judge() external view returns (address)
 ```
 
 ## Development


### PR DESCRIPTION
Fixes:

- [x] rename winner manager to judge
- [x] remove `reward` argument
- [x] accept list of winners

Does not implement:
- [ ] allow multiple judges (and track their count)
- [ ] once a minimum number of judges have voted, choose the winner by majority

We can upgrade how the Judge works by changing the `Judge` to a smart contract encapsulating any business logic.
