### PR TITLE
Add peer id to submit reward

### DIFF
--- a/script/DeployLocalMockData.s.sol
+++ b/script/DeployLocalMockData.s.sol
@@ -116,23 +116,23 @@ contract DeployLocalMockData is Script {
 
         // Submit rewards for each round and stage
         vm.broadcast(user1.privateKey);
-        coordinator.submitReward(0, 0, 100);
+        coordinator.submitReward(0, 0, 100, "QmPeer1");
         vm.broadcast(user2.privateKey);
-        coordinator.submitReward(0, 0, 200);
+        coordinator.submitReward(0, 0, 200, "QmPeer2");
         vm.broadcast(user3.privateKey);
-        coordinator.submitReward(0, 0, 300);
+        coordinator.submitReward(0, 0, 300, "QmPeer3");
 
         vm.broadcast(user1.privateKey);
-        coordinator.submitReward(1, 0, 150);
+        coordinator.submitReward(1, 0, 150, "QmPeer1");
         vm.broadcast(user2.privateKey);
-        coordinator.submitReward(1, 0, 250);
+        coordinator.submitReward(1, 0, 250, "QmPeer2");
         vm.broadcast(user3.privateKey);
-        coordinator.submitReward(1, 0, 350);
+        coordinator.submitReward(1, 0, 350, "QmPeer3");
 
         vm.broadcast(user1.privateKey);
-        coordinator.submitReward(2, 0, 175);
+        coordinator.submitReward(2, 0, 175, "QmPeer1");
         vm.broadcast(user2.privateKey);
-        coordinator.submitReward(2, 0, 275);
+        coordinator.submitReward(2, 0, 275, "QmPeer2");
 
         // Get top winners
         (string[] memory topWinners, uint256[] memory winnerWins) = coordinator.winnerLeaderboard(0, 3);

--- a/src/SwarmCoordinator.sol
+++ b/src/SwarmCoordinator.sol
@@ -709,6 +709,9 @@ contract SwarmCoordinator is UUPSUpgradeable {
         // Check if sender has already submitted a reward for this round and stage
         if (_hasSubmittedRoundStageReward[roundNumber][stageNumber][msg.sender]) revert RewardAlreadySubmitted();
 
+        // Check if the peer ID belongs to the sender
+        if (_peerIdToEoa[peerId] != msg.sender) revert InvalidPeerId();
+
         // Record the reward
         _roundStageRewards[roundNumber][stageNumber][msg.sender] = reward;
         _hasSubmittedRoundStageReward[roundNumber][stageNumber][msg.sender] = true;

--- a/src/SwarmCoordinator.sol
+++ b/src/SwarmCoordinator.sol
@@ -99,7 +99,7 @@ contract SwarmCoordinator is UUPSUpgradeable {
     event RoleGranted(bytes32 indexed role, address indexed account, address indexed sender);
     event RoleRevoked(bytes32 indexed role, address indexed account, address indexed sender);
     event RewardSubmitted(
-        address indexed account, uint256 indexed roundNumber, uint256 indexed stageNumber, uint256 reward
+        address indexed account, uint256 indexed roundNumber, uint256 indexed stageNumber, uint256 reward, string peerId
     );
     event CumulativeRewardsUpdated(address indexed account, uint256 totalRewards);
 
@@ -697,8 +697,9 @@ contract SwarmCoordinator is UUPSUpgradeable {
      * @param roundNumber The round number for which to submit the reward
      * @param stageNumber The stage number for which to submit the reward
      * @param reward The reward amount to submit
+     * @param peerId The peer ID receiving rewards
      */
-    function submitReward(uint256 roundNumber, uint256 stageNumber, uint256 reward) external {
+    function submitReward(uint256 roundNumber, uint256 stageNumber, uint256 reward, string calldata peerId) external {
         // Check if round number is valid (must be less than or equal to current round)
         if (roundNumber > _currentRound) revert InvalidRoundNumber();
 
@@ -715,7 +716,7 @@ contract SwarmCoordinator is UUPSUpgradeable {
         // Update total rewards
         _totalRewards[msg.sender] += reward;
 
-        emit RewardSubmitted(msg.sender, roundNumber, stageNumber, reward);
+        emit RewardSubmitted(msg.sender, roundNumber, stageNumber, reward, peerId);
         emit CumulativeRewardsUpdated(msg.sender, _totalRewards[msg.sender]);
     }
 

--- a/test/SwarmCoordinator.t.sol
+++ b/test/SwarmCoordinator.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity ^0.8;
 
-import {Test, console} from "forge-std/Test.sol";
+import {Test} from "forge-std/Test.sol";
 import {SwarmCoordinator} from "../src/SwarmCoordinator.sol";
 
 contract SwarmCoordinatorTest is Test {
@@ -1124,13 +1124,16 @@ contract SwarmCoordinatorTest is Test {
         swarmCoordinator.setStageCount(2);
 
         uint256 reward = 100;
+        string memory peerId1 = "QmPeer1";
 
-        vm.prank(_user1);
+        vm.startPrank(_user1);
+        swarmCoordinator.registerPeer(peerId1);
         vm.expectEmit(true, true, true, true);
-        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward, "QmPeer");
+        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward, peerId1);
         vm.expectEmit(true, true, false, true);
         emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, reward);
-        swarmCoordinator.submitReward(0, 0, reward, "QmPeer");
+        swarmCoordinator.submitReward(0, 0, reward, peerId1);
+        vm.stopPrank();
 
         // Verify reward was recorded
         address[] memory accounts = new address[](1);
@@ -1148,40 +1151,44 @@ contract SwarmCoordinatorTest is Test {
 
         uint256 reward1 = 100;
         uint256 reward2 = 200;
+        string memory peerId1 = "QmPeer1";
 
         // First submission
-        vm.prank(_user1);
-        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer");
+        vm.startPrank(_user1);
+        swarmCoordinator.registerPeer(peerId1);
+        swarmCoordinator.submitReward(0, 0, reward1, peerId1);
 
         // Try to submit again
-        vm.prank(_user1);
         vm.expectRevert(SwarmCoordinator.RewardAlreadySubmitted.selector);
-        swarmCoordinator.submitReward(0, 0, reward2, "QmPeer");
+        swarmCoordinator.submitReward(0, 0, reward2, peerId1);
+        vm.stopPrank();
     }
 
     function test_Anyone_CanSubmitReward_InDifferentStages() public {
         uint256 reward1 = 100;
         uint256 reward2 = 200;
 
+        string memory peerId1 = "QmPeer1";
+
         // Set stage count
         vm.prank(_owner);
         swarmCoordinator.setStageCount(2);
 
         // Submit reward in stage 0
-        vm.prank(_user1);
+        vm.startPrank(_user1);
+        swarmCoordinator.registerPeer(peerId1);
         vm.expectEmit(true, true, true, true);
-        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward1, "QmPeer");
+        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward1, peerId1);
         vm.expectEmit(true, true, false, true);
         emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, reward1);
-        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer");
+        swarmCoordinator.submitReward(0, 0, reward1, peerId1);
 
         // Submit reward in stage 1
-        vm.prank(_user1);
         vm.expectEmit(true, true, true, true);
-        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 1, reward2, "QmPeer");
+        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 1, reward2, peerId1);
         vm.expectEmit(true, true, false, true);
         emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, reward1 + reward2);
-        swarmCoordinator.submitReward(0, 1, reward2, "QmPeer");
+        swarmCoordinator.submitReward(0, 1, reward2, peerId1);
 
         // Verify rewards were recorded correctly
         address[] memory accounts = new address[](1);
@@ -1197,6 +1204,7 @@ contract SwarmCoordinatorTest is Test {
     function test_Anyone_CanSubmitReward_InDifferentRounds() public {
         uint256 reward1 = 100;
         uint256 reward2 = 200;
+        string memory peerId1 = "QmPeer1";
 
         // Set stage count and stage updater
         vm.startPrank(_owner);
@@ -1205,24 +1213,26 @@ contract SwarmCoordinatorTest is Test {
         vm.stopPrank();
 
         // Submit reward in round 0
-        vm.prank(_user1);
+        vm.startPrank(_user1);
+        swarmCoordinator.registerPeer(peerId1);
         vm.expectEmit(true, true, true, true);
-        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward1, "QmPeer");
+        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward1, peerId1);
         vm.expectEmit(true, true, false, true);
         emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, reward1);
-        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer");
+        swarmCoordinator.submitReward(0, 0, reward1, peerId1);
+        vm.stopPrank();
 
         // Advance to next round
         vm.prank(_stageManager);
         swarmCoordinator.updateStageAndRound();
 
         // Submit reward in round 1
-        vm.prank(_user1);
+        vm.startPrank(_user1);
         vm.expectEmit(true, true, true, true);
-        emit SwarmCoordinator.RewardSubmitted(_user1, 1, 0, reward2, "QmPeer");
+        emit SwarmCoordinator.RewardSubmitted(_user1, 1, 0, reward2, peerId1);
         vm.expectEmit(true, true, false, true);
         emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, reward1 + reward2);
-        swarmCoordinator.submitReward(1, 0, reward2, "QmPeer");
+        swarmCoordinator.submitReward(1, 0, reward2, peerId1);
 
         // Verify rewards were recorded correctly
         address[] memory accounts = new address[](1);
@@ -1239,6 +1249,9 @@ contract SwarmCoordinatorTest is Test {
         uint256 reward1 = 100;
         uint256 reward2 = 200;
 
+        string memory peerId1 = "QmPeer1";
+        string memory peerId2 = "QmPeer2";
+
         // Set stage count and stage updater
         vm.startPrank(_owner);
         swarmCoordinator.setStageCount(1);
@@ -1246,16 +1259,20 @@ contract SwarmCoordinatorTest is Test {
         vm.stopPrank();
 
         // Submit reward in round 0
-        vm.prank(_user1);
-        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer");
+        vm.startPrank(_user1);
+        swarmCoordinator.registerPeer(peerId1);
+        swarmCoordinator.submitReward(0, 0, reward1, peerId1);
+        vm.stopPrank();
 
         // Advance to next round
         vm.prank(_stageManager);
         swarmCoordinator.updateStageAndRound();
 
         // Submit reward for round 0 again (as a different user)
-        vm.prank(_user2);
-        swarmCoordinator.submitReward(0, 0, reward2, "QmPeer");
+        vm.startPrank(_user2);
+        swarmCoordinator.registerPeer(peerId2);
+        swarmCoordinator.submitReward(0, 0, reward2, peerId2);
+        vm.stopPrank();
 
         // Verify rewards were recorded correctly
         address[] memory accounts = new address[](2);
@@ -1264,6 +1281,23 @@ contract SwarmCoordinatorTest is Test {
         uint256[] memory rewards = swarmCoordinator.getRoundStageReward(0, 0, accounts);
         assertEq(rewards[0], reward1);
         assertEq(rewards[1], reward2);
+    }
+
+    function test_Nobody_CanSubmitRewards_ForDifferentPeer() public {
+        uint256 reward1 = 100;
+
+        string memory peerId1 = "QmPeer1";
+        string memory peerId2 = "QmPeer2";
+
+        vm.prank(_user1);
+        swarmCoordinator.registerPeer(peerId1);
+
+        vm.prank(_user2);
+        swarmCoordinator.registerPeer(peerId2);
+
+        vm.prank(_user1);
+        vm.expectRevert();
+        swarmCoordinator.submitReward(0, 0, reward1, peerId2);
     }
 
     function test_GetRoundStageReward_MultipleAddresses() public {

--- a/test/SwarmCoordinator.t.sol
+++ b/test/SwarmCoordinator.t.sol
@@ -1127,10 +1127,10 @@ contract SwarmCoordinatorTest is Test {
 
         vm.prank(_user1);
         vm.expectEmit(true, true, true, true);
-        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward);
+        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward, "QmPeer");
         vm.expectEmit(true, true, false, true);
         emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, reward);
-        swarmCoordinator.submitReward(0, 0, reward);
+        swarmCoordinator.submitReward(0, 0, reward, "QmPeer");
 
         // Verify reward was recorded
         address[] memory accounts = new address[](1);
@@ -1151,12 +1151,12 @@ contract SwarmCoordinatorTest is Test {
 
         // First submission
         vm.prank(_user1);
-        swarmCoordinator.submitReward(0, 0, reward1);
+        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer");
 
         // Try to submit again
         vm.prank(_user1);
         vm.expectRevert(SwarmCoordinator.RewardAlreadySubmitted.selector);
-        swarmCoordinator.submitReward(0, 0, reward2);
+        swarmCoordinator.submitReward(0, 0, reward2, "QmPeer");
     }
 
     function test_Anyone_CanSubmitReward_InDifferentStages() public {
@@ -1170,18 +1170,18 @@ contract SwarmCoordinatorTest is Test {
         // Submit reward in stage 0
         vm.prank(_user1);
         vm.expectEmit(true, true, true, true);
-        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward1);
+        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward1, "QmPeer");
         vm.expectEmit(true, true, false, true);
         emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, reward1);
-        swarmCoordinator.submitReward(0, 0, reward1);
+        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer");
 
         // Submit reward in stage 1
         vm.prank(_user1);
         vm.expectEmit(true, true, true, true);
-        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 1, reward2);
+        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 1, reward2, "QmPeer");
         vm.expectEmit(true, true, false, true);
         emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, reward1 + reward2);
-        swarmCoordinator.submitReward(0, 1, reward2);
+        swarmCoordinator.submitReward(0, 1, reward2, "QmPeer");
 
         // Verify rewards were recorded correctly
         address[] memory accounts = new address[](1);
@@ -1207,10 +1207,10 @@ contract SwarmCoordinatorTest is Test {
         // Submit reward in round 0
         vm.prank(_user1);
         vm.expectEmit(true, true, true, true);
-        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward1);
+        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward1, "QmPeer");
         vm.expectEmit(true, true, false, true);
         emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, reward1);
-        swarmCoordinator.submitReward(0, 0, reward1);
+        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer");
 
         // Advance to next round
         vm.prank(_stageManager);
@@ -1219,10 +1219,10 @@ contract SwarmCoordinatorTest is Test {
         // Submit reward in round 1
         vm.prank(_user1);
         vm.expectEmit(true, true, true, true);
-        emit SwarmCoordinator.RewardSubmitted(_user1, 1, 0, reward2);
+        emit SwarmCoordinator.RewardSubmitted(_user1, 1, 0, reward2, "QmPeer");
         vm.expectEmit(true, true, false, true);
         emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, reward1 + reward2);
-        swarmCoordinator.submitReward(1, 0, reward2);
+        swarmCoordinator.submitReward(1, 0, reward2, "QmPeer");
 
         // Verify rewards were recorded correctly
         address[] memory accounts = new address[](1);
@@ -1247,7 +1247,7 @@ contract SwarmCoordinatorTest is Test {
 
         // Submit reward in round 0
         vm.prank(_user1);
-        swarmCoordinator.submitReward(0, 0, reward1);
+        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer");
 
         // Advance to next round
         vm.prank(_stageManager);
@@ -1255,7 +1255,7 @@ contract SwarmCoordinatorTest is Test {
 
         // Submit reward for round 0 again (as a different user)
         vm.prank(_user2);
-        swarmCoordinator.submitReward(0, 0, reward2);
+        swarmCoordinator.submitReward(0, 0, reward2, "QmPeer");
 
         // Verify rewards were recorded correctly
         address[] memory accounts = new address[](2);
@@ -1276,11 +1276,11 @@ contract SwarmCoordinatorTest is Test {
 
         // Submit rewards for different users
         vm.prank(_user1);
-        swarmCoordinator.submitReward(0, 0, reward1);
+        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer1");
         vm.prank(_user2);
-        swarmCoordinator.submitReward(0, 0, reward2);
+        swarmCoordinator.submitReward(0, 0, reward2, "QmPeer2");
         vm.prank(_user);
-        swarmCoordinator.submitReward(0, 0, reward3);
+        swarmCoordinator.submitReward(0, 0, reward3, "QmPeer3");
 
         // Get rewards for multiple addresses
         address[] memory accounts = new address[](3);
@@ -1312,11 +1312,11 @@ contract SwarmCoordinatorTest is Test {
 
         // Submit rewards for different users
         vm.prank(_user1);
-        swarmCoordinator.submitReward(0, 0, reward1);
+        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer1");
         vm.prank(_user2);
-        swarmCoordinator.submitReward(0, 0, reward2);
+        swarmCoordinator.submitReward(0, 0, reward2, "QmPeer2");
         vm.prank(_user);
-        swarmCoordinator.submitReward(0, 0, reward3);
+        swarmCoordinator.submitReward(0, 0, reward3, "QmPeer3");
 
         // Get total rewards for multiple addresses
         address[] memory accounts = new address[](3);

--- a/test/SwarmCoordinator.t.sol
+++ b/test/SwarmCoordinator.t.sol
@@ -1308,13 +1308,25 @@ contract SwarmCoordinatorTest is Test {
         uint256 reward2 = 200;
         uint256 reward3 = 300;
 
+        string memory peerId1 = "QmPeer1";
+        string memory peerId2 = "QmPeer2";
+        string memory peerId3 = "QmPeer3";
+
         // Submit rewards for different users
-        vm.prank(_user1);
-        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer1");
-        vm.prank(_user2);
-        swarmCoordinator.submitReward(0, 0, reward2, "QmPeer2");
-        vm.prank(_user);
-        swarmCoordinator.submitReward(0, 0, reward3, "QmPeer3");
+        vm.startPrank(_user1);
+        swarmCoordinator.registerPeer(peerId1);
+        swarmCoordinator.submitReward(0, 0, reward1, peerId1);
+        vm.stopPrank();
+
+        vm.startPrank(_user2);
+        swarmCoordinator.registerPeer(peerId2);
+        swarmCoordinator.submitReward(0, 0, reward2, peerId2);
+        vm.stopPrank();
+
+        vm.startPrank(_user);
+        swarmCoordinator.registerPeer(peerId3);
+        swarmCoordinator.submitReward(0, 0, reward3, peerId3);
+        vm.stopPrank();
 
         // Get rewards for multiple addresses
         address[] memory accounts = new address[](3);
@@ -1344,13 +1356,25 @@ contract SwarmCoordinatorTest is Test {
         uint256 reward2 = 200;
         uint256 reward3 = 300;
 
+        string memory peerId1 = "QmPeer1";
+        string memory peerId2 = "Qmpeer2";
+        string memory peerId3 = "QmPeer3";
+
         // Submit rewards for different users
-        vm.prank(_user1);
-        swarmCoordinator.submitReward(0, 0, reward1, "QmPeer1");
-        vm.prank(_user2);
-        swarmCoordinator.submitReward(0, 0, reward2, "QmPeer2");
-        vm.prank(_user);
-        swarmCoordinator.submitReward(0, 0, reward3, "QmPeer3");
+        vm.startPrank(_user1);
+        swarmCoordinator.registerPeer(peerId1);
+        swarmCoordinator.submitReward(0, 0, reward1, peerId1);
+        vm.stopPrank();
+
+        vm.startPrank(_user2);
+        swarmCoordinator.registerPeer(peerId2);
+        swarmCoordinator.submitReward(0, 0, reward2, peerId2);
+        vm.stopPrank();
+
+        vm.startPrank(_user);
+        swarmCoordinator.registerPeer(peerId3);
+        swarmCoordinator.submitReward(0, 0, reward3, peerId3);
+        vm.stopPrank();
 
         // Get total rewards for multiple addresses
         address[] memory accounts = new address[](3);


### PR DESCRIPTION
The dashboard tracks rewards on a per-peer basis. In the previous version of the contract, there was a 1-to-1 mapping of EOA-to-PeerID, but now we need to know which peer received the rewards.