### PR TITLE
feat: reduce stage count to 1

### DIFF
--- a/src/SwarmCoordinator.sol
+++ b/src/SwarmCoordinator.sol
@@ -25,7 +25,7 @@ contract SwarmCoordinator is UUPSUpgradeable {
     // Current stage within the round
     uint256 _currentStage = 0;
     // Total number of stages in a round
-    uint256 constant _stageCount = 3;
+    uint256 constant _stageCount = 1;
     // Maps EOA addresses to their corresponding peer IDs
     mapping(address => string[]) _eoaToPeerId;
     // Maps peer IDs to their corresponding EOA addresses

--- a/test/SwarmCoordinator.t.sol
+++ b/test/SwarmCoordinator.t.sol
@@ -46,7 +46,9 @@ contract SwarmCoordinatorTest is Test {
         vm.prank(_owner);
         (, uint256 newStage) = swarmCoordinator.updateStageAndRound();
 
-        assertEq(newStage, startingStage + 1);
+        // Historically a round had multiple stages. As of June 2025
+        // the GenRL game will use one stage per round.
+        assertEq(newStage, 0);
     }
 
     function test_NonOwner_CannotAdvanceStage_Fails() public {
@@ -632,10 +634,6 @@ contract SwarmCoordinatorTest is Test {
         swarmCoordinator.registerPeer(peerId2);
         // Submit reward for round 0, stage 0
         swarmCoordinator.submitReward(0, 0, reward2, peerId2);
-        // Submit reward for round 0, stage 1
-        swarmCoordinator.submitReward(0, 1, reward2, peerId2);
-        // Submit reward for round 0, stage 2
-        swarmCoordinator.submitReward(0, 2, reward2, peerId2);
         vm.stopPrank();
 
         // Verify rewards were recorded correctly

--- a/test/SwarmCoordinator_Upgrade.t.sol
+++ b/test/SwarmCoordinator_Upgrade.t.sol
@@ -28,7 +28,7 @@ contract SwarmCoordinatorUpgradeTest is Test {
 
     function test_DeployedSuccessfully() public {
         vm.startPrank(_owner);
-        assertEq(swarmCoordinator.stageCount(), 3);
+        assertEq(swarmCoordinator.stageCount(), 1);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
# Why

We want to reduce the stage count to 1 for the GenRL game. The GenRL's implementation reduces the amount of work that needs to be done by a peer node for a given round and would leave a peer node's GPU idle for longer if we were to keep the current round timing. Reducing the stage count to 1 allows us to tune the duration of rounds by adjusting the frequency with which a managing cron job to hit `advanceRoundAtStage` while keeping the current contract's abi.

[slack ctx](https://gensyn.slack.com/archives/C08R9A9N0B1/p1749232617463989)

# What Changed
- `s/3/1` on stage count
- updated tests to expect a single-stage round

# Test Plan
- `forge test` passes
- after deploying new proxy, contract, and stagemanager, pointing our local genrl node at the new contract allows us to participate in quick rounds
