### PR TITLE
Winner/Reward submission time lock

### DIFF
--- a/src/SwarmCoordinator.sol
+++ b/src/SwarmCoordinator.sol
@@ -466,13 +466,13 @@ contract SwarmCoordinator is UUPSUpgradeable {
      * @dev Submits winners for multiple rounds. Callable once per TIME_LOCK_DURATION
      * @param roundNumbers Array of round numbers for which to submit winners
      * @param winners Array of peer ID winners per round
-     * @param peerId The peer ID of the voter
+     * @param peerIds Array of peer IDs of the voters
      */
-    function batchSubmitWinners(uint256[] calldata roundNumbers, string[][] calldata winners, string calldata peerId) external winnerTimeLock {
-        require(roundNumbers.length == winners.length, MismatchedBatchInputLengths());
+    function batchSubmitWinners(uint256[] calldata roundNumbers, string[][] calldata winners, string[] calldata peerIds) external winnerTimeLock {
+        require(roundNumbers.length == winners.length && roundNumbers.length == peerIds.length, MismatchedBatchInputLengths());
 
         for (uint256 i = 0; i < roundNumbers.length; i++) {
-            _submitWinners(roundNumbers[i], winners[i], peerId);
+            _submitWinners(roundNumbers[i], winners[i], peerIds[i]);
         }
     }
 
@@ -579,18 +579,18 @@ contract SwarmCoordinator is UUPSUpgradeable {
      * @param roundNumbers Array of round numbers for which to submit rewards
      * @param stageNumbers Array of stage numbers for which to submit rewards
      * @param rewards Array of reward amounts to submit (can be positive or negative)
-     * @param peerId The peer ID reporting the rewards
+     * @param peerIds Array of peer IDs reporting the rewards
      */
-    function submitBatchRewards(
+    function batchSubmitRewards(
         uint256[] calldata roundNumbers,
         uint256[] calldata stageNumbers,
         uint256[] calldata rewards,
-        string calldata peerId
+        string[] calldata peerIds 
     ) external rewardTimeLock {
-        require(roundNumbers.length == stageNumbers.length && roundNumbers.length == rewards.length, MismatchedBatchInputLengths());
+        require(roundNumbers.length == stageNumbers.length && roundNumbers.length == rewards.length && roundNumbers.length == peerIds.length, MismatchedBatchInputLengths());
 
         for (uint256 i = 0; i < roundNumbers.length; i++) {
-            _submitReward(roundNumbers[i], stageNumbers[i], int256(rewards[i]), peerId);
+            _submitReward(roundNumbers[i], stageNumbers[i], int256(rewards[i]), peerIds[i]);
         }
     }
 

--- a/src/SwarmCoordinator.sol
+++ b/src/SwarmCoordinator.sol
@@ -74,9 +74,15 @@ contract SwarmCoordinator is UUPSUpgradeable {
 
     mapping(bytes32 => mapping(address => bool)) private _roleToAddress;
 
+    // Time locks for submitWinners and submitReward functions
+    // These should only be modified by the corresponding modifier
+    mapping(address => uint256) private _lastWinnersSubmissionTime;
+    mapping(address => uint256) private _lastRewardSubmissionTime;
+
     bytes32 public constant OWNER_ROLE = keccak256("OWNER_ROLE");
     bytes32 public constant BOOTNODE_MANAGER_ROLE = keccak256("BOOTNODE_MANAGER_ROLE");
     bytes32 public constant STAGE_MANAGER_ROLE = keccak256("STAGE_MANAGER_ROLE");
+    uint256 public constant TIME_LOCK_DURATION = 3 hours; // 3 hour time lock for winner/reward submissions
 
     // .-------------------------------------------------------------.
     // | ██████████                                  █████           |
@@ -126,6 +132,8 @@ contract SwarmCoordinator is UUPSUpgradeable {
     error RewardAlreadySubmitted();
     error InvalidStageNumber();
     error InvalidVote();
+    error TimeLockActive();
+    error MismatchedBatchInputLengths();
 
     // .-------------------------------------------------------------------------------------.
     // | ██████   ██████              █████  ███     ██████   ███                            |
@@ -153,6 +161,27 @@ contract SwarmCoordinator is UUPSUpgradeable {
     // Bootnode manager modifier
     modifier onlyBootnodeManager() {
         require(_roleToAddress[BOOTNODE_MANAGER_ROLE][msg.sender], OnlyBootnodeManager());
+        _;
+    }
+
+    // Restricts winner submissions to once per TIME_LOCK_DURATION
+    error TestTimeLockActive(uint256 blockTime, uint256 lastSubmissionTime);
+    modifier winnerTimeLock() {
+        // Check if the time lock has passed since the last winners submission
+        require(block.timestamp >= _lastWinnersSubmissionTime[msg.sender] + TIME_LOCK_DURATION, TestTimeLockActive(block.timestamp, _lastWinnersSubmissionTime[msg.sender]));
+    
+        // Update the last winners submission time
+        _lastWinnersSubmissionTime[msg.sender] = block.timestamp;
+        _;
+    }
+
+    // Restricts reward submissions to once per TIME_LOCK_DURATION
+    modifier rewardTimeLock() {
+        // Check if the time lock has passed since the last reward submission
+        require(block.timestamp >= _lastRewardSubmissionTime[msg.sender] + TIME_LOCK_DURATION, TestTimeLockActive(block.timestamp, _lastRewardSubmissionTime[msg.sender]));
+
+        // Update the last reward submission time
+        _lastRewardSubmissionTime[msg.sender] = block.timestamp;
         _;
     }
 
@@ -423,12 +452,31 @@ contract SwarmCoordinator is UUPSUpgradeable {
     // '-------------------------------------------------------------------------------------'
 
     /**
-     * @dev Submits a list of winners for a specific round
+     * @dev Submits a list of winners for a specific round. Callable once per TIME_LOCK_DURATION
+     * @notice This function is deprecated - batchSubmitWinners should be used instead
      * @param roundNumber The round number for which to submit the winners
      * @param winners The list of peer IDs that should win
      * @param peerId The peer ID of the voter
      */
-    function submitWinners(uint256 roundNumber, string[] memory winners, string calldata peerId) external {
+    function submitWinners(uint256 roundNumber, string[] memory winners, string calldata peerId) external winnerTimeLock {
+        _submitWinners(roundNumber, winners, peerId);
+    }
+
+    /**
+     * @dev Submits winners for multiple rounds. Callable once per TIME_LOCK_DURATION
+     * @param roundNumbers Array of round numbers for which to submit winners
+     * @param winners Array of peer ID winners per round
+     * @param peerId The peer ID of the voter
+     */
+    function batchSubmitWinners(uint256[] calldata roundNumbers, string[][] calldata winners, string calldata peerId) external winnerTimeLock {
+        require(roundNumbers.length == winners.length, MismatchedBatchInputLengths());
+
+        for (uint256 i = 0; i < roundNumbers.length; i++) {
+            _submitWinners(roundNumbers[i], winners[i], peerId);
+        }
+    }
+
+    function _submitWinners(uint256 roundNumber, string[] memory winners, string calldata peerId) internal {
         // Check if round number is valid (must be less than or equal to current round)
         if (roundNumber > _currentRound) revert InvalidRoundNumber();
 
@@ -503,24 +551,50 @@ contract SwarmCoordinator is UUPSUpgradeable {
     }
 
     /**
-     * @dev Monkey patch to accept uint256 rewards, temporary solution
+     * @dev Monkey patch to accept uint256 rewards, temporary solution. Callable once per TIME_LOCK_DURATION 
+     * @notice This function is deprecated - batchSubmitRewards should be used instead
      * @param roundNumber The round number for which to submit the reward
      * @param stageNumber The stage number for which to submit the reward
      * @param reward The reward amount to submit (can be positive or negative)
      * @param peerId The peer ID reporting the rewards
      */
-    function submitReward(uint256 roundNumber, uint256 stageNumber, uint256 reward, string calldata peerId) external {
-        submitReward(roundNumber, stageNumber, int256(reward), peerId);
+    function submitReward(uint256 roundNumber, uint256 stageNumber, uint256 reward, string calldata peerId) external rewardTimeLock {
+        _submitReward(roundNumber, stageNumber, int256(reward), peerId);
     }
 
     /**
-     * @dev Submits a reward for a specific round and stage
+     * @dev Submits a reward for a specific round and stage. Callable once per TIME_LOCK_DURATION
+     * @notice This function is deprecated - batchSubmitRewards should be used instead
      * @param roundNumber The round number for which to submit the reward
      * @param stageNumber The stage number for which to submit the reward
      * @param reward The reward amount to submit (can be positive or negative)
      * @param peerId The peer ID reporting the rewards
      */
-    function submitReward(uint256 roundNumber, uint256 stageNumber, int256 reward, string calldata peerId) public {
+    function submitReward(uint256 roundNumber, uint256 stageNumber, int256 reward, string calldata peerId) external rewardTimeLock{
+        _submitReward(roundNumber, stageNumber, reward, peerId);
+    }
+
+    /**
+     * @dev Submits rewards for multiple round and stage combinations. Callable once per TIME_LOCK_DURATION
+     * @param roundNumbers Array of round numbers for which to submit rewards
+     * @param stageNumbers Array of stage numbers for which to submit rewards
+     * @param rewards Array of reward amounts to submit (can be positive or negative)
+     * @param peerId The peer ID reporting the rewards
+     */
+    function submitBatchRewards(
+        uint256[] calldata roundNumbers,
+        uint256[] calldata stageNumbers,
+        uint256[] calldata rewards,
+        string calldata peerId
+    ) external rewardTimeLock {
+        require(roundNumbers.length == stageNumbers.length && roundNumbers.length == rewards.length, MismatchedBatchInputLengths());
+
+        for (uint256 i = 0; i < roundNumbers.length; i++) {
+            _submitReward(roundNumbers[i], stageNumbers[i], int256(rewards[i]), peerId);
+        }
+    }
+
+    function _submitReward(uint256 roundNumber, uint256 stageNumber, int256 reward, string calldata peerId) internal {
         // Check if round number is valid (must be less than or equal to current round)
         if (roundNumber > _currentRound) revert InvalidRoundNumber();
 

--- a/src/SwarmCoordinator.sol
+++ b/src/SwarmCoordinator.sol
@@ -165,11 +165,12 @@ contract SwarmCoordinator is UUPSUpgradeable {
     }
 
     // Restricts winner submissions to once per TIME_LOCK_DURATION
-    error TestTimeLockActive(uint256 blockTime, uint256 lastSubmissionTime);
     modifier winnerTimeLock() {
         // Check if the time lock has passed since the last winners submission
-        require(block.timestamp >= _lastWinnersSubmissionTime[msg.sender] + TIME_LOCK_DURATION, TestTimeLockActive(block.timestamp, _lastWinnersSubmissionTime[msg.sender]));
-    
+        if (_lastWinnersSubmissionTime[msg.sender] > 0) {
+            require(block.timestamp >= _lastWinnersSubmissionTime[msg.sender] + TIME_LOCK_DURATION, TimeLockActive());
+        }
+
         // Update the last winners submission time
         _lastWinnersSubmissionTime[msg.sender] = block.timestamp;
         _;
@@ -178,7 +179,9 @@ contract SwarmCoordinator is UUPSUpgradeable {
     // Restricts reward submissions to once per TIME_LOCK_DURATION
     modifier rewardTimeLock() {
         // Check if the time lock has passed since the last reward submission
-        require(block.timestamp >= _lastRewardSubmissionTime[msg.sender] + TIME_LOCK_DURATION, TestTimeLockActive(block.timestamp, _lastRewardSubmissionTime[msg.sender]));
+        if (_lastRewardSubmissionTime[msg.sender] > 0) {
+            require(block.timestamp >= _lastRewardSubmissionTime[msg.sender] + TIME_LOCK_DURATION, TimeLockActive());
+        }
 
         // Update the last reward submission time
         _lastRewardSubmissionTime[msg.sender] = block.timestamp;

--- a/test/SwarmCoordinator.t.sol
+++ b/test/SwarmCoordinator.t.sol
@@ -856,4 +856,141 @@ contract SwarmCoordinatorTest is Test {
         vm.expectRevert(SwarmCoordinator.TimeLockActive.selector);
         swarmCoordinator.submitReward(1, 0, reward, peerId);
     }
+
+    function test_BatchSubmitWinners_Successfully() public {
+        string[] memory winners1 = new string[](2);
+        winners1[0] = "QmWinner1";
+        winners1[1] = "QmWinner2";
+
+        string[] memory winners2 = new string[](2);
+        winners2[0] = "QmWinner3";
+        winners2[1] = "QmWinner4";
+
+        string memory voterPeerId = "QmVoter1";
+
+        uint256[] memory rounds = new uint256[](2);
+        rounds[0] = 0;
+        rounds[1] = 1;
+
+        string[][] memory winners = new string[][](2);
+        winners[0] = winners1;
+        winners[1] = winners2;
+
+        string[] memory voterPeerIds = new string[](2);
+        voterPeerIds[0] = voterPeerId;
+        voterPeerIds[1] = voterPeerId;
+
+        // Register peer ID first
+        vm.prank(_user1);
+        swarmCoordinator.registerPeer(voterPeerId);
+
+        // Advance to round 2
+        _forwardToNextRound();
+        _forwardToNextRound();
+
+        // Batch submit winners for round 0
+        vm.prank(_user1);
+        vm.expectEmit(true, true, true, true);
+        emit SwarmCoordinator.WinnerSubmitted(_user1, voterPeerId, 0, winners1);
+        emit SwarmCoordinator.WinnerSubmitted(_user1, voterPeerId, 0, winners2);
+        swarmCoordinator.batchSubmitWinners(rounds, winners, voterPeerIds);
+
+        // Verify votes
+        string[] memory voterVotes = swarmCoordinator.getVoterVotes(0, voterPeerId);
+        assertEq(voterVotes.length, 2);
+        assertEq(voterVotes[0], winners1[0]);
+        assertEq(voterVotes[1], winners1[1]);
+
+        voterVotes = swarmCoordinator.getVoterVotes(1, voterPeerId);
+        assertEq(voterVotes.length, 2);
+        assertEq(voterVotes[0], winners2[0]);
+        assertEq(voterVotes[1], winners2[1]);
+    }
+
+    function test_BatchSubmitWinners_InvalidInput() public {
+        uint256[] memory rounds = new uint256[](2);
+        uint256[] memory invalidRounds = new uint256[](1);
+
+        string[][] memory winners = new string[][](2);
+        string[][] memory invalidWinners = new string[][](1);
+
+        string[] memory voterPeerIds = new string[](2);
+        string[] memory invalidVoterPeerIds = new string[](1);
+
+        vm.expectRevert(SwarmCoordinator.MismatchedBatchInputLengths.selector);
+        swarmCoordinator.batchSubmitWinners(invalidRounds, winners, voterPeerIds);
+
+        vm.expectRevert(SwarmCoordinator.MismatchedBatchInputLengths.selector);
+        swarmCoordinator.batchSubmitWinners(rounds, invalidWinners, voterPeerIds);
+
+        vm.expectRevert(SwarmCoordinator.MismatchedBatchInputLengths.selector);
+        swarmCoordinator.batchSubmitWinners(rounds, winners, invalidVoterPeerIds);
+    }
+
+    function test_BatchSubmitRewards_Successfully() public {
+        uint256[] memory roundIds = new uint256[](2);
+        roundIds[0] = 0;
+        roundIds[1] = 1;
+
+        uint256[] memory stageNumbers = new uint256[](2);
+        stageNumbers[0] = 0;
+        stageNumbers[1] = 0;
+
+        uint256[] memory rewards = new uint256[](2);
+        rewards[0] = 100;
+        rewards[1] = 200;
+
+        string[] memory peerIds = new string[](2);
+        peerIds[0] = "QmPeer1";
+        peerIds[1] = "QmPeer2";
+
+        // Register peer IDs first
+        vm.prank(_user1);
+        swarmCoordinator.registerPeer(peerIds[0]);
+        vm.prank(_user1);
+        swarmCoordinator.registerPeer(peerIds[1]);
+
+        // Advance to round 2
+        _forwardToNextRound();
+        _forwardToNextRound();
+
+        // Batch submit rewards for rounds 0 and 1
+        vm.prank(_user1);
+        vm.expectEmit(true, true, true, true);
+        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, int256(rewards[0]), peerIds[0]);
+        vm.expectEmit(true, true, true, true);
+        emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, peerIds[0], int256(rewards[0]));
+        vm.expectEmit(true, true, true, true);
+        emit SwarmCoordinator.RewardSubmitted(_user1, 1, 0, int256(rewards[1]), peerIds[1]);
+        vm.expectEmit(true, true, true, true);
+        emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, peerIds[1], int256(rewards[1]));
+
+        swarmCoordinator.batchSubmitRewards(roundIds, stageNumbers, rewards, peerIds);
+    }
+
+    function test_BatchSubmitRewards_InvalidInput() public {
+        uint256[] memory roundIds = new uint256[](2);
+        uint256[] memory invalidRoundIds = new uint256[](1);
+
+        uint256[] memory stageNumbers = new uint256[](2);
+        uint256[] memory invalidStageNumbers = new uint256[](1);
+
+        uint256[] memory rewards = new uint256[](2);
+        uint256[] memory invalidRewards = new uint256[](1);
+
+        string[] memory peerIds = new string[](2);
+        string[] memory invalidPeerIds = new string[](1);
+
+        vm.expectRevert(SwarmCoordinator.MismatchedBatchInputLengths.selector);
+        swarmCoordinator.batchSubmitRewards(invalidRoundIds, stageNumbers, rewards, peerIds);
+
+        vm.expectRevert(SwarmCoordinator.MismatchedBatchInputLengths.selector);
+        swarmCoordinator.batchSubmitRewards(roundIds, invalidStageNumbers, rewards, peerIds);
+
+        vm.expectRevert(SwarmCoordinator.MismatchedBatchInputLengths.selector);
+        swarmCoordinator.batchSubmitRewards(roundIds, stageNumbers, invalidRewards, peerIds);
+
+        vm.expectRevert(SwarmCoordinator.MismatchedBatchInputLengths.selector);
+        swarmCoordinator.batchSubmitRewards(roundIds, stageNumbers, rewards, invalidPeerIds);
+    }
 }

--- a/test/SwarmCoordinator.t.sol
+++ b/test/SwarmCoordinator.t.sol
@@ -461,6 +461,7 @@ contract SwarmCoordinatorTest is Test {
 
         // Try to vote again
         vm.prank(_user1);
+        vm.warp(block.timestamp + swarmCoordinator.TIME_LOCK_DURATION()); // bypass time lock
         vm.expectRevert(SwarmCoordinator.WinnerAlreadyVoted.selector);
         swarmCoordinator.submitWinners(0, winners, winners[0]);
     }
@@ -501,6 +502,7 @@ contract SwarmCoordinatorTest is Test {
         swarmCoordinator.submitReward(0, 0, reward1, peerId1);
 
         // Try to submit again with same peer ID
+        vm.warp(block.timestamp + swarmCoordinator.TIME_LOCK_DURATION()); // bypass time lock
         vm.expectRevert(SwarmCoordinator.RewardAlreadySubmitted.selector);
         swarmCoordinator.submitReward(0, 0, reward2, peerId1);
         vm.stopPrank();
@@ -521,6 +523,7 @@ contract SwarmCoordinatorTest is Test {
         swarmCoordinator.submitReward(0, 0, reward1, peerId1);
 
         // Submit reward with second peer ID
+        vm.warp(block.timestamp + swarmCoordinator.TIME_LOCK_DURATION()); // bypass time lock
         swarmCoordinator.submitReward(0, 0, reward2, peerId2);
         vm.stopPrank();
 
@@ -554,6 +557,7 @@ contract SwarmCoordinatorTest is Test {
 
         // Submit reward in stage 1
         vm.startPrank(_user1);
+        vm.warp(block.timestamp + swarmCoordinator.TIME_LOCK_DURATION()); // bypass time lock
         vm.expectEmit(true, true, true, true);
         emit SwarmCoordinator.RewardSubmitted(_user1, 0, 1, reward2, peerId1);
         vm.expectEmit(true, true, true, true);
@@ -594,6 +598,7 @@ contract SwarmCoordinatorTest is Test {
 
         // Submit reward in round 1
         vm.startPrank(_user1);
+        vm.warp(block.timestamp + swarmCoordinator.TIME_LOCK_DURATION()); // bypass time lock
         vm.expectEmit(true, true, true, true);
         emit SwarmCoordinator.RewardSubmitted(_user1, 1, 0, reward2, peerId1);
         vm.expectEmit(true, true, true, true);
@@ -798,5 +803,57 @@ contract SwarmCoordinatorTest is Test {
         // Verify vote count
         uint256 voteCount = swarmCoordinator.getVoterVoteCount(voterPeerId);
         assertEq(voteCount, 1, "Registered voter should have correct vote count");
+    }
+
+    function test_SubmitWinners_TimeLocked() public {
+        string[] memory winners1 = new string[](1);
+        winners1[0] = "QmWinner1";
+        string[] memory winners2 = new string[](1);
+        winners2[0] = "QmWinner2";
+       
+        string memory voterPeerId = "QmVoter1";
+
+        // Register peer IDs first
+        vm.prank(_user1);
+        swarmCoordinator.registerPeer(voterPeerId);
+
+        // Submit winners for round 0
+        vm.prank(_user1);
+        vm.expectEmit(true, true, true, true);
+        emit SwarmCoordinator.WinnerSubmitted(_user1, voterPeerId, 0, winners1);
+        swarmCoordinator.submitWinners(0, winners1, voterPeerId);
+
+        // Forward to next round
+        _forwardToNextRound();
+
+        // Submit winners for round 1 before the time lock expires
+        vm.prank(_user1);
+        vm.expectRevert(SwarmCoordinator.TimeLockActive.selector);
+        swarmCoordinator.submitWinners(1, winners2, voterPeerId);
+    }
+
+    function test_SubmitReward_TimeLocked() public {
+        int256 reward = 100;
+        string memory peerId = "QmPeer1";
+
+        // Register peer ID first
+        vm.prank(_user1);
+        swarmCoordinator.registerPeer(peerId);
+
+        // Submit reward for round 0, stage 0
+        vm.prank(_user1);
+        vm.expectEmit(true, true, true, true);
+        emit SwarmCoordinator.RewardSubmitted(_user1, 0, 0, reward, peerId);
+        vm.expectEmit(true, true, true, true);
+        emit SwarmCoordinator.CumulativeRewardsUpdated(_user1, peerId, reward);
+        swarmCoordinator.submitReward(0, 0, reward, peerId);
+
+        // Forward to next round
+        _forwardToNextRound();
+
+        // Try to submit reward for round 1 before the time lock expires
+        vm.prank(_user1);
+        vm.expectRevert(SwarmCoordinator.TimeLockActive.selector);
+        swarmCoordinator.submitReward(1, 0, reward, peerId);
     }
 }


### PR DESCRIPTION
- Adds a time lock with a 3 hour expiry to `submitReward` and `submitWinners` to meter gas usage. 3 hours is the submission interval for RLSwarm nodes >= [v0.5.6](https://github.com/gensyn-ai/rl-swarm/releases/tag/v0.5.6)
- Adds `batchSubmitReward` and `batchSubmitWinners` so that rewards and winners may be submitted for multiple historical rounds. Without this, the time lock on `submitReward` and `submitWinners` effectively restricts a node to participating in a single round every three hours

Each address' time lock is initialized to the default value, 0. This means the lock will be populated with a real time stamp the first time a user calls `submitReward` or `submitWinners` after this is deployed. As a result, time lock expiry, and therefore gas consumption, will be distributed over the 3 hours, rather than being concentrated at a given point. 